### PR TITLE
Fixed inaccurate square size bug by modifying "create_segments" to use Earth Engine methods

### DIFF
--- a/GEE_Mines/step3_routine.py
+++ b/GEE_Mines/step3_routine.py
@@ -521,34 +521,40 @@ def get_B6(feature):
 """
 Segment the given geometry into squares of given size (in km)
 :param geometry: rectangle form geometry object
+:param size:     square size
 :return:         list of all created squares
 """
 def create_segments(geometry, size):
-    segments = []
-    r_earth, dy, dx, pi = ee.Number(6378), ee.Number(size), ee.Number(size), ee.Number(math.pi)
-    
+    # grab the top left coordinate of the bounding box
     coords = ee.List(geometry.coordinates().get(0)).slice(0, -1)
-    
     top = ee.Number(ee.List(coords.get(2)).get(1))
     left = ee.Number(ee.List(coords.get(0)).get(0))
+    top_left_point = ee.Geometry.Point([left, top])
     
-    width = int(ee.Geometry.Point(coords.get(0)).distance(ee.Geometry.Point(coords.get(1))).divide(1000 * size).getInfo())
-    height = int(ee.Geometry.Point(coords.get(1)).distance(ee.Geometry.Point(coords.get(2))).divide(1000 * size).getInfo())
-
-    for y in range(height + 1):
+    # calculate square pixel width and height
+    width = int(ee.Geometry.Point(coords.get(0)).distance(ee.Geometry.Point(coords.get(1))).divide(1000 * size).getInfo()) # how many squares can fit in the width of the bounding box
+    height = int(ee.Geometry.Point(coords.get(1)).distance(ee.Geometry.Point(coords.get(2))).divide(1000 * size).getInfo()) # how many squares can fit in the height of the bounding box
+    
+    # create a point buffer and use it to find the km distance to lat/lon degree conversion
+    buff = top_left_point.buffer(size*1000, 0.1) # create the buffer with a max % error of 0.1
+    buff_list = ee.List(buff.coordinates().get(0)) 
+    buff_length = buff_list.length()
+    right_pt = ee.List(buff_list.get(buff_length.multiply(0.75).int().subtract(1)))
+    bottom_pt = ee.List(buff_list.get(buff_length.multiply(0.5).int().subtract(1)))
+    new_lat = ee.Number(right_pt.get(0)) # given distance east of the top left point
+    new_lon = ee.Number(bottom_pt.get(1)) # given distance south of the top left point
+    
+    diff_lon = top.subtract(new_lon) # given size converted to degrees
+    diff_lat = new_lat.subtract(left)
+    
+    # build the list of squares
+    segments = []
+    
+    for y in range(height + 1): # +1 to guarantee we will cover the whole region (squares may extend slightly past the bounding box)
         left = ee.Number(ee.List(coords.get(0)).get(0))
         for x in range(width + 1):
-            #
-            first = top
-            second = dx.divide(r_earth)
-            third = ee.Number(180).divide(pi)
-            con = pi.divide(ee.Number(180))
-            fourth = left.multiply(con).multiply(con).cos()
-            
-            new_lon = first.subtract(second.multiply(third).divide(fourth))
-            #new_lon = top - (dx / r_earth) * (180 / pi) / math.cos(math.radians(left * pi/180))
-            #new_lat = left  + (dy / r_earth) * (180 / pi)
-            new_lat = left.add((dy.divide(r_earth)).multiply((ee.Number(180).divide(pi))))
+            new_lat = left.add(diff_lat)
+            new_lon = top.subtract(diff_lon)
             
             square = ee.Geometry.Polygon(
                 [[[left, new_lon],
@@ -562,7 +568,6 @@ def create_segments(geometry, size):
         top = new_lon
         
     return segments
-
 # routine
 def filter_by_vegetation_loss(squares, threshold1, threshold2):
     with_percent_change = squares.map(calculate_percentage_change)


### PR DESCRIPTION
Noticed that the original distance formula I was using was inaccurate while looking at the Mojave: DRC squares were ~250x250m while Mojave squares were ~200x250m. Changed the function to use Earth Engine's buffer method instead to fix the issue