### PR TITLE
Add scores after step3 instead of after step5

### DIFF
--- a/GEE_Mines/step3_routine.py
+++ b/GEE_Mines/step3_routine.py
@@ -730,3 +730,4 @@ with open(complete_path, 'w') as f:
 
 f.close()
 
+os.system('python3 step5a_add_scores.py ' + file_name)

--- a/GEE_Mines/step5_compile.py
+++ b/GEE_Mines/step5_compile.py
@@ -9,4 +9,3 @@ os.system("rm -rf batch/routine*") # remove batch files
 os.system("rm queue.txt") # remove temp queue file
 os.system("rm failed.txt") # remove failed jobs txt file
 os.system("rm start_routine.sh") # remove step 1 bash file
-os.system("python3 step5a_add_scores.py compiled") # call next step with desired csv file name (do not include .csv)

--- a/GEE_Mines/step5a_add_scores.py
+++ b/GEE_Mines/step5a_add_scores.py
@@ -87,5 +87,4 @@ for row in new_array:
 #             B5 Value, B6 Value, Center Lat, Center Lon, Elevation Score, Band Variation Score'
 # final = np.savetxt("results/compiled_scores.csv", new_array2, delimiter=",", header=header_list)
 final = np.savetxt("results/" + file_name + "_scores.csv", new_array2, delimiter=",")
-
-os.system("python3 step6_status_and_convert.py " + file_name)
+os.system('rm results/' + file_name + '.csv')

--- a/GEE_Mines/step6_status_and_convert.py
+++ b/GEE_Mines/step6_status_and_convert.py
@@ -80,4 +80,4 @@ task = ee.batch.Export.table.toAsset(**{
   'assetId': 'users/EmilyNason/FinalResults', # change to your GEE Asset path and a unique name (will not overwrite already existing assets, so old names cannot be reused)
 });
 
-# task.start()
+task.start()

--- a/GEE_Mines/step6_status_and_convert.py
+++ b/GEE_Mines/step6_status_and_convert.py
@@ -10,7 +10,7 @@ file_name = sys.argv[1]
 # Passing region results only will be saved in "[file_name]_status_passing.csv"
 
 # Open the input file in read mode and output file in write mode
-with open('results/' + file_name + '_scores.csv', 'r') as read_obj, \
+with open('results/' + file_name + '.csv', 'r') as read_obj, \
         open('results/' + file_name + '_status.csv', 'w', newline='') as write_obj:
     # Create a csv.reader object from the input file object
     csv_reader = reader(read_obj)
@@ -80,4 +80,4 @@ task = ee.batch.Export.table.toAsset(**{
   'assetId': 'users/EmilyNason/FinalResults', # change to your GEE Asset path and a unique name (will not overwrite already existing assets, so old names cannot be reused)
 });
 
-task.start()
+# task.start()


### PR DESCRIPTION
Ran into some issues where the code would get stuck and freeze up on the scoring step for very large files. Moved scoring step from after compiling results to before compiling results (scores are now added to each small .csv before compiling all .csvs)